### PR TITLE
[TASK] Make port an integer in configuration example

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,7 +12,7 @@ TYPO3:
 #     type: 'Swift_SmtpTransport'
 #     options:
 #       host: 'smtp.example.com'
-#       port: '465'
+#       port: 465
 #       username: 'myaccount@example.com'
 #       password: '5js9j1lkjs8'
 #       encryption: 'ssl'


### PR DESCRIPTION
The example for setting up SMTP as transport had the port number as a string.
