### PR TITLE
TASK: Complete TLS/SSL SMTP example and documentation

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,6 +6,7 @@ TYPO3:
       options: []
 
 # Example settings for sending emails via SMTP / SSL:
+# Encryption can be set to either tls or ssl
 #
 # SwiftMailer:
 #   transport:
@@ -13,6 +14,7 @@ TYPO3:
 #     options:
 #       host: 'smtp.example.com'
 #       port: 465
+#       encryption: 'ssl'
 #       username: 'myaccount@example.com'
 #       password: '5js9j1lkjs8'
 #       localDomain: 'example.com'


### PR DESCRIPTION
The TLS/SSL SMTP example is incomplete as it misses the encryption property. 
Since port 465 is normally used for SSL, the example uses ssl value, but tls is
added as a possibility on top of the example.