### PR TITLE
Adjust docs about setting the email body

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -78,8 +78,8 @@ Here is an example:
       ->setTo(array($recipientAddress => $recipientName))
       ->setSubject($subject);
 
-  $mail->setBody($message, 'text/html');
-  $mail->setBody($message, 'text/plain');
+  $mail->setBody($messageTxt, 'text/plain');
+  $mail->addPart($messageHtml, 'text/html');
 
   $mail->send();
 


### PR DESCRIPTION
Using "setBody" a second time on the mail object overrides the first call. To add a body with another content type you need to use "addPart". 
At the moment the documentation about that is rather confusing.

Please correct me if I understood something wrong. With the current documented way I run into some issues overriding myself. 